### PR TITLE
T-0024 Увеличить область захвата для небольших пазлов

### DIFF
--- a/src/models/tile-geometries/RegularPolygonTileGeometry.ts
+++ b/src/models/tile-geometries/RegularPolygonTileGeometry.ts
@@ -1,4 +1,6 @@
+import { Polygon } from "pixi.js";
 import { TileGeometry } from "./TileGeometry.ts";
+import { Algorithm } from "../../math/Algorithm.ts";
 
 /**
  * Класс геометрии построения элемента замощения, являющегося правильным многоугольником.
@@ -59,5 +61,14 @@ export abstract class RegularPolygonTileGeometry extends TileGeometry {
     protected setCircumscribedAndInscribedCircleRadiuses() {
         this.circumscribedCircleRadius = this.side * this.circumscribedCircleRadiusToSideRatio;
         this.inscribedCircleRadius = this.side * this.inscribedCircleRadiusToSideRatio;
+    }
+
+    protected getHitAreaRegularPolygon(hitAreaSizeMultiplier: number): Polygon {
+        return Algorithm.getRegularPolygon(
+            this.pivotPoint,
+            this.circumscribedCircleRadius * hitAreaSizeMultiplier,
+            this.sideCount,
+            this.regularPolygonInitialRotationAngle
+        );
     }
 }

--- a/src/models/tile-geometries/polygon-bases/HexagonBaseGeometry.ts
+++ b/src/models/tile-geometries/polygon-bases/HexagonBaseGeometry.ts
@@ -25,5 +25,6 @@ export class HexagonBaseGeometry extends RegularPolygonTileGeometry {
     constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
         super(baseValue, 6, sideToBaseValueRatio);
         this.setCircumscribedAndInscribedCircleRadiuses();
+        this.regularPolygonInitialRotationAngle = Math.PI / 6.0;
     }
 }

--- a/src/models/tile-geometries/polygon-bases/OctagonBaseGeometry.ts
+++ b/src/models/tile-geometries/polygon-bases/OctagonBaseGeometry.ts
@@ -27,5 +27,6 @@ export class OctagonBaseGeometry extends RegularPolygonTileGeometry {
     constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
         super(baseValue, 8, sideToBaseValueRatio);
         this.setCircumscribedAndInscribedCircleRadiuses();
+        this.regularPolygonInitialRotationAngle = 3 / 8.0 * Math.PI;
     }
 }

--- a/src/models/tile-geometries/polygon-bases/SquareBaseGeometry.ts
+++ b/src/models/tile-geometries/polygon-bases/SquareBaseGeometry.ts
@@ -22,5 +22,6 @@ export class SquareBaseGeometry extends RegularPolygonTileGeometry {
     constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
         super(baseValue, 4, sideToBaseValueRatio);
         this.setCircumscribedAndInscribedCircleRadiuses();
+        this.regularPolygonInitialRotationAngle = Math.PI / 4;
     }
 }

--- a/src/models/tile-geometries/polygon-bases/TriangleBaseGeometry.ts
+++ b/src/models/tile-geometries/polygon-bases/TriangleBaseGeometry.ts
@@ -31,6 +31,7 @@ export class TriangleBaseGeometry extends RegularPolygonTileGeometry {
     constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
         super(baseValue, 3, sideToBaseValueRatio);
         this.setCircumscribedAndInscribedCircleRadiuses();
+        this.regularPolygonInitialRotationAngle = 0;
         this.height = this.circumscribedCircleRadius + this.inscribedCircleRadius;
     }
 }

--- a/src/models/tile-geometries/polygons-with-single-locks/HexagonWithSingleLockGeometry.ts
+++ b/src/models/tile-geometries/polygons-with-single-locks/HexagonWithSingleLockGeometry.ts
@@ -1,5 +1,4 @@
 import { Point } from "pixi.js";
-import { Algorithm } from "../../../math/Algorithm.ts";
 import { Size } from "../../../math/Size.ts";
 import { TileLockType } from "../../tile-locks/TileLockType.ts";
 import { HexagonBaseGeometry } from "../polygon-bases/HexagonBaseGeometry.ts";
@@ -36,7 +35,11 @@ c-4-2.9-4.8-8.4-2-12.4c5-6.9,3.5-16.5-3.4-21.5s-16.5-3.5-21.5,3.4c-3.9,5.4-3.9,1
 c0,4.9-4,8.9-8.9,8.9c0,0-51.2,0-51.2,0L45.3,82.9c-2.4,4.2-1,9.7,3.2,12.1c1.6,0.9,3.5,1.3,5.4,1.1c6.6-0.7,13,3,15.7,9
 c3.5,7.8,0,16.9-7.8,20.4C54,129,44.9,125.5,41.4,117.7z`;
 
-    constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
+    constructor(
+        baseValue: number,
+        sideToBaseValueRatio: number = 1,
+        hitAreaSizeMultiplier: number = 1
+    ) {
         super(baseValue, sideToBaseValueRatio);
 
         this.freedomDegree = this.sideCount / 2;
@@ -49,12 +52,7 @@ c3.5,7.8,0,16.9-7.8,20.4C54,129,44.9,125.5,41.4,117.7z`;
             this.side * 2,
             this.inscribedCircleRadius * 2 + this.lockHeight
         );
-        this.hitArea = Algorithm.getRegularPolygon(
-            this.pivotPoint,
-            this.circumscribedCircleRadius,
-            6,
-            this.regularPolygonInitialRotationAngle
-        );
+        this.hitArea = this.getHitAreaRegularPolygon(hitAreaSizeMultiplier);
         this.maxBoundingSize = Math.max(
             2 * this.circumscribedCircleRadius,
             2 * this.inscribedCircleRadius + this.lockHeight

--- a/src/models/tile-geometries/polygons-with-single-locks/OctagonWithSingleLockGeometry.ts
+++ b/src/models/tile-geometries/polygons-with-single-locks/OctagonWithSingleLockGeometry.ts
@@ -1,5 +1,4 @@
 import { Point } from "pixi.js";
-import { Algorithm } from "../../../math/Algorithm.ts";
 import { Size } from "../../../math/Size.ts";
 import { TileLockType } from "../../tile-locks/TileLockType.ts";
 import { OctagonBaseGeometry } from "../polygon-bases/OctagonBaseGeometry.ts";
@@ -40,7 +39,11 @@ c-1.3,1.3-2.2,3-2.5,4.9c-1,6.6-6.2,11.7-12.8,12.8c-8.4,1.3-16.3-4.4-17.6-12.8c-1
 c4.8-0.8,8.1-5.3,7.4-10.2c-0.3-1.8-1.2-3.6-2.5-4.9l-36.2-36.2c0,0-51.2,0-51.2,0c-1.9,0-3.7-0.6-5.2-1.7
 C220.1,34,219.2,28.4,222.1,24.5z`;
 
-    constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
+    constructor(
+        baseValue: number,
+        sideToBaseValueRatio: number = 1,
+        hitAreaSizeMultiplier: number = 1
+    ) {
         super(baseValue, sideToBaseValueRatio);
 
         this.freedomDegree = this.sideCount / 2;
@@ -58,12 +61,7 @@ C220.1,34,219.2,28.4,222.1,24.5z`;
             defaultBoundingRectangleSide,
             defaultBoundingRectangleSide
         );
-        this.hitArea = Algorithm.getRegularPolygon(
-            this.pivotPoint,
-            this.circumscribedCircleRadius,
-            8,
-            this.regularPolygonInitialRotationAngle
-        );
+        this.hitArea = this.getHitAreaRegularPolygon(hitAreaSizeMultiplier);
         this.maxBoundingSize = Math.max(
             2 * this.circumscribedCircleRadius,
             2 * (this.inscribedCircleRadius + this.lockHeight)

--- a/src/models/tile-geometries/polygons-with-single-locks/SquareWithSingleLockGeometry.ts
+++ b/src/models/tile-geometries/polygons-with-single-locks/SquareWithSingleLockGeometry.ts
@@ -1,4 +1,4 @@
-import { Point, Polygon } from "pixi.js";
+import { Point } from "pixi.js";
 import { TileLockType } from "../../tile-locks/TileLockType.ts";
 import { TileGeometryType } from "../TileGeometryType.ts";
 import { Size } from "../../../math/Size.ts";
@@ -31,7 +31,11 @@ c-1.9,0-3.7-0.6-5.2-1.7c-4-2.9-4.8-8.4-2-12.4c5-6.9,3.5-16.5-3.4-21.5c-6.9-5-16.
 c1.1,1.5,1.7,3.3,1.7,5.2c0,4.9-4,8.9-8.9,8.9c0,0-51.2,0-51.2,0v51.2c0,4.9,4,8.9,8.9,8.9c1.9,0,3.7-0.6,5.2-1.7
 c5.4-3.9,12.7-3.9,18.1,0c6.9,5,8.4,14.6,3.4,21.5C30.6,125.3,21,126.9,14.1,121.9z`;
 
-    constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
+    constructor(
+        baseValue: number,
+        sideToBaseValueRatio: number = 1,
+        hitAreaSizeMultiplier: number = 1
+    ) {
         super(baseValue, sideToBaseValueRatio);
 
         this.freedomDegree = this.sideCount / 2;
@@ -42,12 +46,7 @@ c5.4-3.9,12.7-3.9,18.1,0c6.9,5,8.4,14.6,3.4,21.5C30.6,125.3,21,126.9,14.1,121.9z
         const sideHalf = this.side / 2.0;
         this.pivotPoint = new Point(sideHalf, sideHalf + this.lockHeight);
         this.defaultBoundingRectangleSize = new Size(this.side, this.side + this.lockHeight * 2);
-        this.hitArea = new Polygon([
-            new Point(0, this.lockHeight),
-            new Point(this.side, this.lockHeight),
-            new Point(this.side, this.side + this.lockHeight),
-            new Point(0, this.side + this.lockHeight)
-        ]);
+        this.hitArea = this.getHitAreaRegularPolygon(hitAreaSizeMultiplier);
         this.maxBoundingSize = Math.max(
             2 * this.circumscribedCircleRadius,
             2 * (this.inscribedCircleRadius + this.lockHeight)

--- a/src/models/tile-geometries/polygons/HexagonGeometry.ts
+++ b/src/models/tile-geometries/polygons/HexagonGeometry.ts
@@ -1,7 +1,6 @@
 import { Point } from "pixi.js";
 import { TileGeometryType } from "../TileGeometryType.ts";
 import { Size } from "../../../math/Size.ts";
-import { Algorithm } from "../../../math/Algorithm.ts";
 import { HexagonBaseGeometry } from "../polygon-bases/HexagonBaseGeometry.ts";
 
 /**
@@ -15,24 +14,22 @@ import { HexagonBaseGeometry } from "../polygon-bases/HexagonBaseGeometry.ts";
 export class HexagonGeometry extends HexagonBaseGeometry {
     public readonly geometryType: TileGeometryType = TileGeometryType.Hexagon;
 
-    constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
+    constructor(
+        baseValue: number,
+        sideToBaseValueRatio: number = 1,
+        hitAreaSizeMultiplier: number = 1
+    ) {
         super(baseValue, sideToBaseValueRatio);
 
         this.freedomDegree = this.sideCount;
         this.freedomDegreeRotationAngle = this.getFreedomDegreeRotationAngle();
 
-        this.pivotPoint = new Point(this.side, this.inscribedCircleRadius);
-        this.regularPolygonInitialRotationAngle = Math.PI / 6.0;   
+        this.pivotPoint = new Point(this.side, this.inscribedCircleRadius);           
         this.defaultBoundingRectangleSize = new Size(
             this.side * 2,
             this.inscribedCircleRadius * 2
         );        
-        this.hitArea = Algorithm.getRegularPolygon(
-            this.pivotPoint,
-            this.circumscribedCircleRadius,
-            6,
-            this.regularPolygonInitialRotationAngle
-        );
+        this.hitArea = this.getHitAreaRegularPolygon(hitAreaSizeMultiplier);
         this.maxBoundingSize = this.circumscribedCircleRadius * 2;
     }
 }

--- a/src/models/tile-geometries/polygons/OctagonGeometry.ts
+++ b/src/models/tile-geometries/polygons/OctagonGeometry.ts
@@ -1,7 +1,6 @@
 import { Point } from "pixi.js";
 import { TileGeometryType } from "../TileGeometryType.ts";
 import { Size } from "../../../math/Size.ts";
-import { Algorithm } from "../../../math/Algorithm.ts";
 import { OctagonBaseGeometry } from "../polygon-bases/OctagonBaseGeometry.ts";
 
 /**
@@ -16,23 +15,21 @@ import { OctagonBaseGeometry } from "../polygon-bases/OctagonBaseGeometry.ts";
 export class OctagonGeometry extends OctagonBaseGeometry {
     public readonly geometryType: TileGeometryType = TileGeometryType.Octagon;
 
-    constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
+    constructor(
+        baseValue: number,
+        sideToBaseValueRatio: number = 1,
+        hitAreaSizeMultiplier: number = 1
+    ) {
         super(baseValue, sideToBaseValueRatio);
 
         this.freedomDegree = this.sideCount;
         this.freedomDegreeRotationAngle = this.getFreedomDegreeRotationAngle();
 
         const inscribedCircleDiameter = this.inscribedCircleRadius * 2;
-        this.pivotPoint = new Point(this.inscribedCircleRadius, this.inscribedCircleRadius);
-        this.regularPolygonInitialRotationAngle = 3 / 8.0 * Math.PI;     
+        this.pivotPoint = new Point(this.inscribedCircleRadius, this.inscribedCircleRadius);             
         this.defaultBoundingRectangleSize = new Size(inscribedCircleDiameter,
             inscribedCircleDiameter);
-        this.hitArea = Algorithm.getRegularPolygon(
-            this.pivotPoint,
-            this.circumscribedCircleRadius,
-            8,
-            this.regularPolygonInitialRotationAngle
-        );
+        this.hitArea = this.getHitAreaRegularPolygon(hitAreaSizeMultiplier);
         this.maxBoundingSize = this.circumscribedCircleRadius * 2;
     }
 }

--- a/src/models/tile-geometries/polygons/SquareGeometry.ts
+++ b/src/models/tile-geometries/polygons/SquareGeometry.ts
@@ -1,4 +1,4 @@
-import { Point, Polygon } from "pixi.js";
+import { Point } from "pixi.js";
 import { TileGeometryType } from "../TileGeometryType.ts";
 import { Size } from "../../../math/Size.ts";
 import { SquareBaseGeometry } from "../polygon-bases/SquareBaseGeometry.ts";
@@ -15,22 +15,20 @@ import { SquareBaseGeometry } from "../polygon-bases/SquareBaseGeometry.ts";
 export class SquareGeometry extends SquareBaseGeometry {
     public readonly geometryType: TileGeometryType = TileGeometryType.Square;
 
-    constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
+    constructor(
+        baseValue: number,
+        sideToBaseValueRatio: number = 1,
+        hitAreaSizeMultiplier: number = 1
+    ) {
         super(baseValue, sideToBaseValueRatio);
 
         this.freedomDegree = this.sideCount;
         this.freedomDegreeRotationAngle = this.getFreedomDegreeRotationAngle();
 
         const sideHalf = this.side / 2.0;
-        this.pivotPoint = new Point(sideHalf, sideHalf);
-        this.regularPolygonInitialRotationAngle = Math.PI / 4;      
+        this.pivotPoint = new Point(sideHalf, sideHalf);              
         this.defaultBoundingRectangleSize = new Size(this.side, this.side);
-        this.hitArea = new Polygon([
-            new Point(0, 0),
-            new Point(this.side, 0),
-            new Point(this.side, this.side),
-            new Point(0, this.side)
-        ]);
+        this.hitArea = this.getHitAreaRegularPolygon(hitAreaSizeMultiplier);
         this.maxBoundingSize = this.circumscribedCircleRadius * 2;
     }
 }

--- a/src/models/tile-geometries/polygons/TriangleGeometry.ts
+++ b/src/models/tile-geometries/polygons/TriangleGeometry.ts
@@ -1,4 +1,4 @@
-import { Point, Polygon } from "pixi.js";
+import { Point } from "pixi.js";
 import { TileGeometryType } from "../TileGeometryType.ts";
 import { Size } from "../../../math/Size.ts";
 import { TriangleBaseGeometry } from "../polygon-bases/TriangleBaseGeometry.ts";
@@ -15,21 +15,20 @@ import { TriangleBaseGeometry } from "../polygon-bases/TriangleBaseGeometry.ts";
 export class TriangleGeometry extends TriangleBaseGeometry {
     public readonly geometryType: TileGeometryType = TileGeometryType.Triangle;
 
-    constructor(baseValue: number, sideToBaseValueRatio: number = 1) {
+    constructor(
+        baseValue: number,
+        sideToBaseValueRatio: number = 1,
+        hitAreaSizeMultiplier: number = 1
+    ) {
         super(baseValue, sideToBaseValueRatio);
 
         this.freedomDegree = this.sideCount;
         this.freedomDegreeRotationAngle = this.getFreedomDegreeRotationAngle();
 
         const sideHalf = this.side / 2.0;
-        this.pivotPoint = new Point(sideHalf, this.circumscribedCircleRadius);
-        this.regularPolygonInitialRotationAngle = 0;        
+        this.pivotPoint = new Point(sideHalf, this.circumscribedCircleRadius);                
         this.defaultBoundingRectangleSize = new Size(this.side, this.height);
-        this.hitArea = new Polygon([
-            new Point(sideHalf, 0),
-            new Point(this.side, this.height),
-            new Point(0, this.height)
-        ]);
+        this.hitArea = this.getHitAreaRegularPolygon(hitAreaSizeMultiplier);
         this.maxBoundingSize = this.circumscribedCircleRadius * 2;
     }
 }

--- a/src/models/tilings/OctagonAndSquareTilingBaseModel.ts
+++ b/src/models/tilings/OctagonAndSquareTilingBaseModel.ts
@@ -17,6 +17,14 @@ import { RectangularGridTilingModel } from "./RectangularGridTilingModel";
  * чем столбцов, содержащих восьмиугольники.
  */
 export abstract class OctagonAndSquareTilingBaseModel extends RectangularGridTilingModel {
+    /**
+     * Множитель области попадания квадрата.
+     * Квадраты значительно меньше восьмиугольников в даном замощении,
+     * и пользователю сложно по ним попадать.
+     * Поэтому расширяем зоны попадания в квадраты на величину этого множителя.
+     */
+    public static readonly squareHitAreaSizeMultiplier: number = (Math.sqrt(2) + 0.8) / Math.sqrt(2);
+
     public getGridIndicesAreCorrect(rowIndex: number, columnIndex: number): boolean {
         return rowIndex >= 0
             && rowIndex < this.tileRowCount

--- a/src/models/tilings/OctagonAndSquareTilingBaseModel.ts
+++ b/src/models/tilings/OctagonAndSquareTilingBaseModel.ts
@@ -23,7 +23,7 @@ export abstract class OctagonAndSquareTilingBaseModel extends RectangularGridTil
      * и пользователю сложно по ним попадать.
      * Поэтому расширяем зоны попадания в квадраты на величину этого множителя.
      */
-    public static readonly squareHitAreaSizeMultiplier: number = (Math.sqrt(2) + 0.8) / Math.sqrt(2);
+    public static readonly squareHitAreaSizeMultiplier: number = 1 + 0.8 / Math.sqrt(2);
 
     public getGridIndicesAreCorrect(rowIndex: number, columnIndex: number): boolean {
         return rowIndex >= 0

--- a/src/models/tilings/TilingModel.ts
+++ b/src/models/tilings/TilingModel.ts
@@ -48,6 +48,15 @@ export abstract class TilingModel {
      */
     public maxTileBoundingSizesByTileGeometryTypes: Map<TileGeometryType, number>
         = new Map<TileGeometryType, number>();
+    /**
+     * Карта, где по типу геометрии элемента мозаики можно найти его z-индекс,
+     * то есть уровень расположения в контейнере замощения.
+     * Это нужно для назначения приоритетов зонам попадания пазлов соответствующих геометрий:
+     * выше предполагается располагать небольшие пазлы с расширенными зонами попадания,
+     * которые будут частично накрывать пазлы больших размеров.
+     */
+    public tileZIndicesByTileGeometryTypes: Map<TileGeometryType, number>
+        = new Map<TileGeometryType, number>();
 
     /**
      * Карта, где по строковому представлению позиции

--- a/src/models/tilings/polygons-with-single-locks/HexagonWithSingleLockTilingModel.ts
+++ b/src/models/tilings/polygons-with-single-locks/HexagonWithSingleLockTilingModel.ts
@@ -53,6 +53,8 @@ export class HexagonWithSingleLockTilingModel extends RectangularGridTilingModel
      * с одинарными замками, один экземпляр на все элементы мозаики
      */
     private tileGeometry?: HexagonWithSingleLockGeometry;
+    public tileZIndicesByTileGeometryTypes: Map<TileGeometryType, number>
+        = new Map<TileGeometryType, number>([[TileGeometryType.HexagonWithSingleLock, 0]]);
 
     /**
      * Создание замощения правильными шестиугольниками с одинарными замками

--- a/src/models/tilings/polygons-with-single-locks/OctagonAndSquareWithSpiralLockTilingModel.ts
+++ b/src/models/tilings/polygons-with-single-locks/OctagonAndSquareWithSpiralLockTilingModel.ts
@@ -75,6 +75,11 @@ export class OctagonAndSquareWithSpiralLockTilingModel
      * один экземпляр на все квадраты мозаики
      */
     private squareTileGeometry?: SquareWithSingleLockGeometry;
+    public tileZIndicesByTileGeometryTypes: Map<TileGeometryType, number>
+        = new Map<TileGeometryType, number>([
+            [TileGeometryType.OctagonWithSingleLock, 0],
+            [TileGeometryType.SquareWithSingleLock, 1],
+        ]);
 
     /**
      * Создание замощения правильными восьмиугольниками и квадратами с одинарными замками
@@ -138,7 +143,8 @@ export class OctagonAndSquareWithSpiralLockTilingModel
     protected initializeImageTileInfo(): void {
         const tileSide = this.textureTileSide * this.imageContainerModel.sideToTextureSideRatio;
         this.octagonTileGeometry = new OctagonWithSingleLockGeometry(tileSide);
-        this.squareTileGeometry = new SquareWithSingleLockGeometry(tileSide);
+        this.squareTileGeometry = new SquareWithSingleLockGeometry(tileSide, 1,
+            OctagonAndSquareTilingBaseModel.squareHitAreaSizeMultiplier);
         this.maxTileBoundingSizesByTileGeometryTypes.set(TileGeometryType.OctagonWithSingleLock,
             this.octagonTileGeometry.maxBoundingSize);
         this.maxTileBoundingSizesByTileGeometryTypes.set(TileGeometryType.SquareWithSingleLock,

--- a/src/models/tilings/polygons-with-single-locks/SquareWithSingleLockTilingModel.ts
+++ b/src/models/tilings/polygons-with-single-locks/SquareWithSingleLockTilingModel.ts
@@ -51,6 +51,8 @@ export class SquareWithSingleLockTilingModel extends RectangularGridTilingModel 
      * один экземпляр на все элементы мозаики
      */
     private tileGeometry?: SquareWithSingleLockGeometry;
+    public tileZIndicesByTileGeometryTypes: Map<TileGeometryType, number>
+        = new Map<TileGeometryType, number>([[TileGeometryType.SquareWithSingleLock, 0]]);
 
     /**
      * Создание замощения квадратами c одинарными замками

--- a/src/models/tilings/polygons/HexagonTilingModel.ts
+++ b/src/models/tilings/polygons/HexagonTilingModel.ts
@@ -46,6 +46,8 @@ export class HexagonTilingModel extends RectangularGridTilingModel {
      * один экземпляр на все элементы мозаики
      */
     private tileGeometry?: HexagonGeometry;
+    public tileZIndicesByTileGeometryTypes: Map<TileGeometryType, number>
+        = new Map<TileGeometryType, number>([[TileGeometryType.Hexagon, 0]]);
 
     /**
      * Создание замощения правильными шестиугольниками

--- a/src/models/tilings/polygons/OctagonAndSquareTilingModel.ts
+++ b/src/models/tilings/polygons/OctagonAndSquareTilingModel.ts
@@ -58,6 +58,11 @@ export class OctagonAndSquareTilingModel extends OctagonAndSquareTilingBaseModel
      * один экземпляр на все квадраты мозаики
      */
     private squareTileGeometry?: SquareGeometry;
+    public tileZIndicesByTileGeometryTypes: Map<TileGeometryType, number>
+        = new Map<TileGeometryType, number>([
+            [TileGeometryType.Octagon, 0],
+            [TileGeometryType.Square, 1],
+        ]);
 
     /**
      * Создание замощения правильными восьмиугольниками и квадратами
@@ -112,7 +117,8 @@ export class OctagonAndSquareTilingModel extends OctagonAndSquareTilingBaseModel
     protected initializeImageTileInfo(): void {
         const tileSide = this.textureTileSide * this.imageContainerModel.sideToTextureSideRatio;
         this.octagonTileGeometry = new OctagonGeometry(tileSide);
-        this.squareTileGeometry = new SquareGeometry(tileSide);
+        this.squareTileGeometry = new SquareGeometry(tileSide, 1,
+            OctagonAndSquareTilingBaseModel.squareHitAreaSizeMultiplier);
         this.maxTileBoundingSizesByTileGeometryTypes.set(TileGeometryType.Octagon,
             this.octagonTileGeometry.maxBoundingSize);
         this.maxTileBoundingSizesByTileGeometryTypes.set(TileGeometryType.Square,
@@ -127,7 +133,7 @@ export class OctagonAndSquareTilingModel extends OctagonAndSquareTilingBaseModel
         const tileIsOctagon = targetTilePosition.rowIndex % 2 === 0;
         const tileGeometry: TileGeometry = tileIsOctagon
             ? this.octagonTileGeometry
-            : this.squareTileGeometry;
+            : this.squareTileGeometry;        
         const result = new TileModel(this.tileParameters, tileGeometry);
         result.targetTilePosition = targetTilePosition.clone();
         result.targetRotationAngle = tileIsOctagon ? 0 : Math.PI / 4.0;

--- a/src/models/tilings/polygons/SquareTilingModel.ts
+++ b/src/models/tilings/polygons/SquareTilingModel.ts
@@ -36,6 +36,8 @@ export class SquareTilingModel extends RectangularGridTilingModel {
      * Инструменты для геометрических построений квадрата, один экземпляр на все квадраты
      */
     private tileGeometry?: SquareGeometry;
+    public tileZIndicesByTileGeometryTypes: Map<TileGeometryType, number>
+        = new Map<TileGeometryType, number>([[TileGeometryType.Square, 0]]);
 
     /**
      * Создание замощения квадратами

--- a/src/models/tilings/polygons/TriangleTilingModel.ts
+++ b/src/models/tilings/polygons/TriangleTilingModel.ts
@@ -49,6 +49,8 @@ export class TriangleTilingModel extends RectangularGridTilingModel {
      * один экземпляр на все элементы мозаики
      */
     private tileGeometry?: TriangleGeometry;
+    public tileZIndicesByTileGeometryTypes: Map<TileGeometryType, number>
+        = new Map<TileGeometryType, number>([[TileGeometryType.Triangle, 0]]);
 
     /**
      * Создание замощения правильными треугольниками

--- a/src/views/components/TileLineContainer.ts
+++ b/src/views/components/TileLineContainer.ts
@@ -279,6 +279,8 @@ export class TileLineContainer extends Container {
                 decoratedView
             );
         }
+
+        this.tilingView.setDraggableTileZIndices();
     }
 
     public resize(targetLongitudinalSize: number): void {

--- a/src/views/tiles/TileBaseView.ts
+++ b/src/views/tiles/TileBaseView.ts
@@ -58,7 +58,7 @@ export abstract class TileBaseView implements TileView {
         result.pivot.set(this.model.geometry.pivotPoint.x, this.model.geometry.pivotPoint.y);        
         result.rotation = this.model.currentRotationAngle;   
         result.position.copyFrom(this.model.currentPositionPoint);
-        result.hitArea = this.content.hitArea;     
+        result.hitArea = this.model.geometry.hitArea.clone();     
         return result;
     }
 

--- a/src/views/tilings/TilingView.ts
+++ b/src/views/tilings/TilingView.ts
@@ -8,6 +8,7 @@ import { DraggableTileView } from "../tile-decorators/DraggableTileView.ts";
 import { TilesAlphaController } from "../controllers/TilesAlphaController.ts";
 import { TileGeometryType } from "../../models/tile-geometries/TileGeometryType.ts";
 import { draggingTileData } from "../tile-decorators/DraggingTileData.ts";
+import { TileView } from "../tiles/TileView.ts";
 
 /**
  * Класс представления замощения
@@ -61,9 +62,11 @@ export class TilingView {
         this.tilingContainer = this.createTilingContainer();
 
         this.staticTilesContainer = new Container();
+        this.staticTilesContainer.sortableChildren = true;
         this.tilingContainer.addChild(this.staticTilesContainer);
 
         this.draggableTilesContainer = new Container();
+        this.draggableTilesContainer.sortableChildren = true;
         this.tilingContainer.addChild(this.draggableTilesContainer);
 
         window.addEventListener(DraggableTileView.draggingTileIsSelectedEventName,
@@ -130,6 +133,8 @@ export class TilingView {
             }
         }
 
+        this.setStaticTileZIndices();
+
         this.staticTilesAlphaController = new TilesAlphaController(
             this.parameters.animationParameters,
             [...this.staticTileViewsByTilePositionStrings.values()],
@@ -163,6 +168,28 @@ export class TilingView {
             const newContent = tileView.createContent(true);
             tileView.view.replaceContent(newContent);
         });
+    }
+
+    private setStaticTileZIndices(): void {
+        const tileViews = [...this.staticTileViewsByTilePositionStrings.values()];
+        return this.setTileZIndices(tileViews);
+    }
+
+    public setDraggableTileZIndices(): void {
+        const tileViews = [...this.draggableTileViewsByTilePositionStrings.values()];
+        return this.setTileZIndices(tileViews);
+    }
+
+    private setTileZIndices(tileViews: TileView[]): void {
+        const setTileZIndex: (tileView: TileView) => void
+            = this.model.tileZIndicesByTileGeometryTypes.size < 2
+            ? tileView => tileView.tile.zIndex = 0
+            : tileView => {
+                const geometryType = tileView.model.geometry.geometryType;
+                const zIndex = this.model.tileZIndicesByTileGeometryTypes.get(geometryType);
+                tileView.tile.zIndex = zIndex === undefined ? 0 : zIndex;
+            };
+        tileViews.forEach(setTileZIndex);
     }
 
     private onDraggingTileIsSelected(event: CustomEvent<DraggableTileView>): void {


### PR DESCRIPTION
Ввела множитель для зоны попадания пазлов.

Нашла и исправила ошибку вычисления зоны попадания (был неверный начальный поворот у пазлов с одинарными замками).

Создала карту, где по типу геометрии элемента мозаики можно найти его z-индекс.

Сделала контейнеры для статических перемещаемых пазлов сортируемыми, то есть поддерживающими z-индексы.

Назначаю всем пазлам, статическим и перемещаемым, z-индексы после их создания.

Всё это позволяет легче захватывать небольшие пазлы, легче помещать их в ячейки и легче крутить пазлы на месте.