### PR TITLE
T-0033 Исправить баги 

### DIFF
--- a/src/math/Algorithm.ts
+++ b/src/math/Algorithm.ts
@@ -268,7 +268,7 @@ export class Algorithm {
             
             // Защита от деления на ноль,
             // хотя при isPointYBetweenVertices === true, edgeDeltaY не должен быть 0
-            if (Math.abs(edgeDeltaY) < 0.000001) {
+            if (edgeDeltaY === 0) {
                 continue;
             }
             

--- a/src/views/components/tile-line/TileLineContainer.ts
+++ b/src/views/components/tile-line/TileLineContainer.ts
@@ -33,6 +33,7 @@ import { TileLineCreationParameters } from "./TileLineCreationParameters.ts";
 export class TileLineContainer extends Container {
     public static readonly tileLineStartResizeEventName: string = "tileLineStartResizeEvent";
     public static readonly tileLineStopResizeEventName: string = "tileLineStopResizeEvent";
+    public static readonly scaleEpsilon = 0.01;
 
     public readonly parameters: TileLineParameters;
     public readonly directionType: TileLineDirectionType;
@@ -74,6 +75,10 @@ export class TileLineContainer extends Container {
     public initialTileScalesByTileGeometryTypes: Map<TileGeometryType, number>
         = new Map<TileGeometryType, number>();
 
+    /**
+     * Прямоугольная зона данного компонента в глобальных координатах
+     */
+    private globalRectangle?: Rectangle;
     /**
      * Прямоугольная зона изменения масштаба элемента мозаики.
      * Когда пользователь захватывает фигуру и начинает двигать,
@@ -180,12 +185,26 @@ export class TileLineContainer extends Container {
      */
     public onAddedToParent(viewportContainer: ViewportContainer): void {
         this.viewportContainer = viewportContainer;
+        this.globalRectangle = this.getGlobalRectangle();
         this.scaleChangeGlobalRectangle = this.getTileScaleChangeGlobalRectangle();
     }
 
     public getPointIsInsideViewportRectangle(globalPoint: Point): boolean {
         return this.getViewportContainerOrThrow()
             .getPointIsInsideViewportRectangle(globalPoint);
+    }
+
+    private getGlobalRectangle(): Rectangle {
+        const viewportContainer = this.getViewportContainerOrThrow();
+        const viewportRectangle = viewportContainer.viewportRectangle;
+        const globalLeftTop = viewportContainer.viewportGlobalPosition;
+
+        return new Rectangle(
+            globalLeftTop.x,
+            globalLeftTop.y,
+            viewportRectangle.width,
+            viewportRectangle.height
+        ); 
     }
 
     private getTileScaleChangeGlobalRectangle(): Rectangle {
@@ -363,6 +382,27 @@ export class TileLineContainer extends Container {
         globalPoint: Point,
         tileView: DraggableTileView
     ): void {
+        if (!this.globalRectangle) {
+            throw new Error('globalRectangle was not created');
+        }
+
+        if (!draggingTileData.viewport) {
+            throw new Error('draggingTileData.viewport should be initialized');
+        }
+
+        const pointIsInsideGlobalRectangle = Algorithm.getPointIsInsideRectangle(
+            globalPoint,
+            this.globalRectangle
+        );
+
+        if (!pointIsInsideGlobalRectangle) {
+            if (Math.abs(tileView.view.tile.scale.x - draggingTileData.viewport.scale.x)
+                > TileLineContainer.scaleEpsilon) {
+                tileView.view.tile.scale = draggingTileData.viewport.scale.x;
+            }
+            return;
+        }
+
         if (!this.scaleChangeGlobalRectangle) {
             throw new Error('tileScaleChangeGlobalRectangle was not created');
         }
@@ -371,14 +411,11 @@ export class TileLineContainer extends Container {
             globalPoint,
             this.scaleChangeGlobalRectangle
         );
+
         if (!shouldChangeScale) {
             return;
         }
         
-        if (!draggingTileData.viewport) {
-            throw new Error('draggingTileData.viewport should be initialized');
-        }
-
         const initialTileScale = this.getInitialTileScaleOrThrow(tileView);
         const tilingViewportScale = draggingTileData.viewport.scale.x;
         const scaleDifference = tilingViewportScale - initialTileScale;

--- a/src/views/tiles/SvgPathTileView.ts
+++ b/src/views/tiles/SvgPathTileView.ts
@@ -47,7 +47,7 @@ export class SvgPathTileView extends TileBaseView {
             graphicsTexture,
             sprite.width,
             sprite.height,
-            2,
+            1,
             0.5
         );
         result.addChild(borderBlurredSpriteWithMask);

--- a/src/views/tiles/TileBaseView.ts
+++ b/src/views/tiles/TileBaseView.ts
@@ -98,6 +98,7 @@ export abstract class TileBaseView implements TileView {
 
     public addFilter(filter: Filter): void {
         if (!this.tile.filters?.length) {
+            filter.padding = 1;
             this.tile.filters = [filter];
             this.tile.updateCacheTexture();
             return;
@@ -109,6 +110,7 @@ export abstract class TileBaseView implements TileView {
         }
 
         const filters = [...this.tile.filters];
+        filter.padding = 1;
         filters.push(filter);
         this.tile.filters = filters;
         this.tile.updateCacheTexture();


### PR DESCRIPTION
Попробовала починить следующие баги.

1. Картинка пазла обрезалась на границах.
Здесь изменение самой картинки несколько усложнило бы код.
Причиной был фильтр размытия на границе.
я уменьшила размер маски фильтра размытия на границе, поэтому выход за границу стал меньше, и результат немного улучшился.

2. При захвате пазла из ячейки происходит двоение подсветки ячейки.
Как оказалось, это артефакт применения фильтра размытия , который немного выходит за границу изображения.
я установила маленькую зону отступа фильтра padding, и артефакт просто стал незаметен.
Если совсем это убрать (padding = 0), то при применении фильтра свечения граница будет казаться усечённой.

3. При перетаскивании пазла с ленты в область картинки пазл часто имеет размеры меньше, чем ожидается.
Этот баг был виден только на сотовом телефоне, протестировать на компьютере не получилось.
Но я сделала так, что когда пазл покидает карусель, он становится принудительно необходимого размера.

4. Иногда отсутствует фокусировка на ячейках для перетаскивания.
Этот баг пока не починился.
я попробовала модифицировать условие в алгоритме, но это, как мне кажется, не повлияло на результат.