### PR TITLE
T-0034 Убирать выделение с ячейки при потере фокуса

### DIFF
--- a/src/views/components/tiling-level/image/TilingLevelImageContainer.ts
+++ b/src/views/components/tiling-level/image/TilingLevelImageContainer.ts
@@ -150,6 +150,10 @@ export class TilingLevelImageContainer extends Container {
             this.uniqueParameters.defaultStaticTileFillColor,
             this.uniqueParameters.targetStaticTileFillColor
         );
+        draggingTileData.tilingView = this.tilingView;
+        this.tilingView.onDestroy = (): void => {
+            draggingTileData.tilingView = undefined;
+        };
 
         this.tilingView.createStaticTileViews(this.renderer, this.ticker);
         this.imageContainer.addChild(this.tilingView.tilingContainer);

--- a/src/views/tile-decorators/DraggableTileView.ts
+++ b/src/views/tile-decorators/DraggableTileView.ts
@@ -108,6 +108,9 @@ export class DraggableTileView implements TileView {
     public isLocatedCorrectly: boolean = false;
     private fixAsLocatedCorrectlyTimer?: number;
 
+    private static readonly staticTileRemoveTargetGlowFilterDelay: number = 100;
+    private staticTileRemoveTargetGlowFilterTimer?: number;
+
     private selectedGlowFilter?: GlowFilter;
     private correctLocatedGlowFilter?: GlowFilter;
 
@@ -512,7 +515,7 @@ export class DraggableTileView implements TileView {
             }
         }
 
-        this.isDragging = false;   
+        this.isDragging = false;
 
         const finalTarget = this.dragTarget;
         const finalSource = this.dragSource;
@@ -585,6 +588,46 @@ export class DraggableTileView implements TileView {
             this.dragTarget = undefined;
             this.initialContainer.addTileView(this);
         }
+
+        this.removeTargetGlowFilterFromStaticTiles();
+    }
+
+    /**
+     * После того, как текущий перемещаемый элемент замощения занял своё место,
+     * иногда остаются подсвеченными посторонние ячейки как целевые.
+     * Это происходит, когда перемещаемый элемент замощения быстро проходит
+     * сначала над потенциальной целевой ячейкой,
+     * а затем проходит над другими перемещаемыми фигурами,
+     * которые в данный момент пассивны и находятся в ячейках.
+     * В этом случае потенциальная целевая ячейка остаётся подсвеченной,
+     * хотя она уже перестаёт быть целевой.
+     * Также из-за быстрого прохода текущей перемещаемой фигуры
+     * может запаздывать событие назначения статической ячейки потенциально целевой.
+     * Поэтому после того, как текущий перемещаемый элемент отпускается указателем,
+     * следует убрать подсветку со всех ячеек, кроме той,
+     * что становится исходной для данного перемещаемого элемента.
+     * Также вводится небольшая задержка, для компенсации запаздывающего события целевой ячейки.
+     */
+    private removeTargetGlowFilterFromStaticTiles(): void {
+        if (!draggingTileData.tilingView) {
+            return;
+        }
+
+        this.staticTileRemoveTargetGlowFilterTimer = setTimeout(() => {
+                if (!draggingTileData.tilingView) {
+                    return;
+                }
+
+                const staticTileViews = [...draggingTileData.tilingView
+                    .staticTileViewsByTilePositionStrings.values()];
+                staticTileViews
+                    .filter(staticTileView => staticTileView !== this.dragSource)
+                    .forEach(staticTileView => staticTileView.removeTargetGlowFilter());
+                
+                this.staticTileRemoveTargetGlowFilterTimer = undefined;
+            },
+            DraggableTileView.staticTileRemoveTargetGlowFilterDelay
+        ); 
     }
 
     private getPointerIsMouseAndButtonIsNotLeft(event: PointerEvent): boolean {
@@ -789,6 +832,11 @@ export class DraggableTileView implements TileView {
         if (this.fixAsLocatedCorrectlyTimer !== undefined) {
             clearTimeout(this.fixAsLocatedCorrectlyTimer);
             this.fixAsLocatedCorrectlyTimer = undefined;
+        }
+
+        if (this.staticTileRemoveTargetGlowFilterTimer !== undefined) {
+            clearTimeout(this.staticTileRemoveTargetGlowFilterTimer);
+            this.staticTileRemoveTargetGlowFilterTimer = undefined;
         }
 
         this.removeEventListeners();

--- a/src/views/tile-decorators/DraggingTileData.ts
+++ b/src/views/tile-decorators/DraggingTileData.ts
@@ -1,6 +1,7 @@
 import { DraggableTileView } from "./DraggableTileView";
 import { ZoomAndPanContainer } from "../components/zoom-and-pan/ZoomAndPanContainer.ts";
 import { TileView } from "../tiles/TileView.ts";
+import { TilingView } from "../tilings/TilingView.ts";
 
 /**
  * Интерфейс информации о фигуре, которая перетаскивается в данный момент.
@@ -8,6 +9,7 @@ import { TileView } from "../tiles/TileView.ts";
 interface DraggingTileData {
     view?: DraggableTileView;
     viewport?: ZoomAndPanContainer;
+    tilingView?: TilingView;
     animatingViews: Set<TileView>;
 }
 
@@ -17,5 +19,6 @@ interface DraggingTileData {
 export const draggingTileData: DraggingTileData = {
     view: undefined,
     viewport: undefined,
+    tilingView: undefined,
     animatingViews: new Set<TileView>()
 };

--- a/src/views/tilings/TilingView.ts
+++ b/src/views/tilings/TilingView.ts
@@ -75,6 +75,8 @@ export class TilingView {
      */
     private showPotentialTargetHintGlowFilterTimer?: number;
 
+    public onDestroy?: () => void;
+
     private boundOnDraggingTileWasSelected: (event: CustomEvent<DraggableTileView>) => void
         = this.onDraggingTileWasSelected.bind(this);
     private boundOnDraggingTileIsDeselected: (event: CustomEvent<DraggableTileView>) => void
@@ -423,5 +425,8 @@ export class TilingView {
         this.staticTilesContainer.destroy();
         this.draggableTilesContainer.destroy();
         this.tilingContainer.destroy();
+
+        this.onDestroy?.();
+        this.onDestroy = undefined;
     }
 }


### PR DESCRIPTION
После того, как текущий перемещаемый элемент замощения занял своё место, иногда остаются подсвеченными посторонние ячейки как целевые.

Это происходит, когда перемещаемый элемент замощения быстро проходит сначала над потенциальной целевой ячейкой, а затем проходит над другими перемещаемыми фигурами, которые в данный момент пассивны и находятся в ячейках.

В этом случае потенциальная целевая ячейка остаётся подсвеченной, хотя она уже перестаёт быть целевой.

Также из-за быстрого прохода текущей перемещаемой фигуры может запаздывать событие назначения статической ячейки потенциально целевой.

Поэтому после того, как текущий перемещаемый элемент отпускается указателем, следует убрать подсветку со всех ячеек, кроме той, что становится исходной для данного перемещаемого элемента.

Также вводится небольшая задержка, для компенсации запаздывающего события целевой ячейки.