### PR TITLE
T-0035 Предотвратить потерю фокуса на потенциальных целевых ячейках

### DIFF
--- a/src/views/tile-decorators/DraggableTileView.ts
+++ b/src/views/tile-decorators/DraggableTileView.ts
@@ -5,7 +5,6 @@ import {
     FederatedPointerEvent,
     Filter,
     Polygon,
-    Matrix,
     IHitArea,
     Ticker,
     Color,
@@ -77,13 +76,6 @@ export class DraggableTileView implements TileView {
      */
     public dragSource?: StaticTileView;
     /**
-     * Зона целевой статической фигуры-ячейки, определяемая указателем.
-     * Исходная ячейка почему-то не определяется как целевая и не реагирует на события мыши.
-     * Эту зону нужно вычислять и хранить для перетаскивания,
-     * потому что под перетаскиваемой фигурой зона не видна.
-     */
-    private dragSourceWorldHitArea?: Polygon;
-    /**
      * Статическая фигура-ячейка, на которую происходит перетаскивание
      */
     public dragTarget?: StaticTileView;
@@ -108,7 +100,7 @@ export class DraggableTileView implements TileView {
     public isLocatedCorrectly: boolean = false;
     private fixAsLocatedCorrectlyTimer?: number;
 
-    private static readonly staticTileRemoveTargetGlowFilterDelay: number = 100;
+    private static readonly staticTileRemoveTargetGlowFilterDelay: number = 150;
     private staticTileRemoveTargetGlowFilterTimer?: number;
 
     private selectedGlowFilter?: GlowFilter;
@@ -485,11 +477,12 @@ export class DraggableTileView implements TileView {
 
         const targetPosition = this.getTargetParentPosition(globalPosition);
 
-        if (this.dragSource && this.dragSourceWorldHitArea) {
+        if (this.dragSource?.worldHitArea) {
             this.tryToEnterToDragSource(
                 this.dragSource,
-                this.dragSourceWorldHitArea,
-                targetPosition
+                this.dragSource.worldHitArea,
+                targetPosition,
+                event
             );
         }
     }
@@ -564,7 +557,7 @@ export class DraggableTileView implements TileView {
         }
 
         if (finalTarget) {
-            this.setDragSource(finalTarget);
+            this.dragSource = finalTarget;
         }
         
         this.dragTarget = this.dragSource;
@@ -613,18 +606,27 @@ export class DraggableTileView implements TileView {
             return;
         }
 
+        if (this.staticTileRemoveTargetGlowFilterTimer !== undefined) {
+            clearTimeout(this.staticTileRemoveTargetGlowFilterTimer);
+            this.staticTileRemoveTargetGlowFilterTimer = undefined;
+        }
+
         this.staticTileRemoveTargetGlowFilterTimer = setTimeout(() => {
+                this.staticTileRemoveTargetGlowFilterTimer = undefined;
+
                 if (!draggingTileData.tilingView) {
                     return;
                 }
 
                 const staticTileViews = [...draggingTileData.tilingView
                     .staticTileViewsByTilePositionStrings.values()];
+                const currentDragTarget = draggingTileData.view?.dragTarget;
                 staticTileViews
-                    .filter(staticTileView => staticTileView !== this.dragSource)
+                    .filter(staticTileView =>
+                        staticTileView !== this.dragSource
+                        && staticTileView !== currentDragTarget
+                    )
                     .forEach(staticTileView => staticTileView.removeTargetGlowFilter());
-                
-                this.staticTileRemoveTargetGlowFilterTimer = undefined;
             },
             DraggableTileView.staticTileRemoveTargetGlowFilterDelay
         ); 
@@ -645,12 +647,14 @@ export class DraggableTileView implements TileView {
      * в координатах родителя
      * @param tileWorldPosition Координаты точки в мире координат,
      * где живёт модель элемента замощения)
+     * @param event Событие, содержащее координаты указателя
      * @returns 
      */
     private tryToEnterToDragSource(
         dragSource: StaticTileView,
         dragSourceTileWorldHitArea: Polygon,
-        tileWorldPosition: Point
+        tileWorldPosition: Point,
+        event: FederatedPointerEvent
     ): boolean {
         const pointerIsInsideHitArea = Algorithm.getPointIsInsidePolygon(
             tileWorldPosition,
@@ -663,7 +667,7 @@ export class DraggableTileView implements TileView {
         }
         
         if (this.dragTarget === dragSource && !pointerIsInsideHitArea) {
-            dragSource.onPointerLeave();
+            dragSource.onPointerLeave(event);
         }
 
         return false;
@@ -715,29 +719,6 @@ export class DraggableTileView implements TileView {
     public getGlobalPosition(): Point {
         return this.view.tile.parent?.toGlobal(this.view.tile.position)
             ?? this.view.tile.position;
-    }
-
-    public setDragSource(dragSource?: StaticTileView): void {
-        this.dragSource = dragSource;
-        if (!dragSource) {
-            this.dragSourceWorldHitArea = undefined;
-            return;
-        }
-
-        const pivotPoint = dragSource.view.model.geometry.pivotPoint;
-        const currentPositionPoint = dragSource.view.model.currentPositionPoint;
-        
-        const tileMatrix = new Matrix()
-            .translate(-pivotPoint.x, -pivotPoint.y)
-            .rotate(dragSource.view.model.currentRotationAngle)
-            .translate(currentPositionPoint.x, currentPositionPoint.y);
-        
-        const tileWorldHitArea = Algorithm.getTransformedPolygon(
-            dragSource.view.model.geometry.hitArea,
-            tileMatrix
-        );
-        
-        this.dragSourceWorldHitArea = tileWorldHitArea;
     }
 
     private getTargetParentPosition(globalPoint: Point): Point {
@@ -794,11 +775,11 @@ export class DraggableTileView implements TileView {
         }
 
         this.fixAsLocatedCorrectlyTimer = setTimeout(() => {
+                this.fixAsLocatedCorrectlyTimer = undefined;
                 this.clearFilters();
                 this.addTileToTargetContainerOnFixAsLocatedCorrectly();
                 const contentWithoutBevelFilter = this.view.createContent(false);
                 this.view.replaceContent(contentWithoutBevelFilter);
-                this.fixAsLocatedCorrectlyTimer = undefined;
             }, 
             this.parameters.correctLocatedFilterShowTime
         );
@@ -844,7 +825,6 @@ export class DraggableTileView implements TileView {
         this.view.tile.hitArea = undefined;
         this.view.content.hitArea = undefined;
         this.clearHitArea();
-        this.dragSourceWorldHitArea = undefined;
         
         this.rotationController.destroy();
         this.moveAfterDragController.destroy();

--- a/src/views/tile-decorators/StaticTileView.ts
+++ b/src/views/tile-decorators/StaticTileView.ts
@@ -1,9 +1,19 @@
-import { Texture, Container, Filter, FederatedPointerEvent, Color } from "pixi.js";
+import {
+    Texture,
+    Container,
+    Filter,
+    FederatedPointerEvent,
+    Color,
+    Polygon,
+    Matrix,
+    Point
+} from "pixi.js";
 import { GlowFilter } from "pixi-filters";
 import { TileModel } from "../../models/tiles/TileModel.ts";
 import { TileView } from "../tiles/TileView.ts";
 import { draggingTileData } from "./DraggingTileData.ts";
 import { StaticTileParameters } from "./StaticTileParameters.ts";
+import { Algorithm } from "../../math/Algorithm.ts";
 
 /**
  * Класс декоратора представления неподвижного элемента замощения,
@@ -16,12 +26,27 @@ export class StaticTileView implements TileView {
      */
     public view: TileView;
     /**
+     * Зона статической фигуры-ячейки, определяемая указателем,
+     * когда он проходит над этой ячейкой.
+     * Эту зону нужно вычислять и хранить,
+     * потому что под перетаскиваемой фигурой во время перетаскивания
+     * факт нахождения над статической ячейкой может быть иногда определён не верно,
+     * поэтому берутся координаты указателя и определяется, попадает ли указатель в данную зону.
+     */
+    public worldHitArea?: Polygon;
+    /**
      * Признак того, что данная статическая фигура является ячейкой-целью
      * для перетаскивания подвижной фигуры
      */
     private isDragTarget: boolean = false;
 
     private targetGlowFilter?: GlowFilter;
+
+    private pointerIsOver: boolean = false;
+    private pointerEnterTimer?: number;
+    private pointerLeaveTimer?: number;
+    private static readonly pointerEnterDelay: number = 50;
+    private static readonly pointerLeaveDelay: number = 50;
 
     /**
      * Создание неподвижного элемента замощения,
@@ -32,6 +57,7 @@ export class StaticTileView implements TileView {
     constructor (parameters: StaticTileParameters, view: TileView) {
         this.parameters = parameters;
         this.view = view;
+        this.setWorldHitArea();
 
         this.view.tile.eventMode = "static";
         this.view.tile.on('pointerenter', this.onPointerEnter, this);
@@ -97,38 +123,88 @@ export class StaticTileView implements TileView {
         return draggingGeometryType === currentGeometryType;
     }
 
+    private setWorldHitArea(): void {
+        const pivotPoint = this.view.model.geometry.pivotPoint;
+        const currentPositionPoint = this.view.model.currentPositionPoint;
+        
+        const tileMatrix = new Matrix()
+            .translate(-pivotPoint.x, -pivotPoint.y)
+            .rotate(this.view.model.currentRotationAngle)
+            .translate(currentPositionPoint.x, currentPositionPoint.y);
+        
+        this.worldHitArea = Algorithm.getTransformedPolygon(
+            this.view.model.geometry.hitArea,
+            tileMatrix
+        );
+    }
+
     public onPointerEnter(): void {
         if (!this.getDraggingTileHasTheSameType()) {
             return;
         }
 
-        if (draggingTileData.view) {
-            if (draggingTileData.view.dragTarget) {
-                draggingTileData.view.dragTarget.removeTargetGlowFilter();
-                draggingTileData.view.dragTarget.isDragTarget = false;
-            }
-            
-            draggingTileData.view.dragTarget = this;
+        if (this.pointerLeaveTimer !== undefined) {
+            clearTimeout(this.pointerLeaveTimer);
+            this.pointerLeaveTimer = undefined;
         }
-        
-        this.isDragTarget = true;
-        
-        const filter = this.getTargetGlowFilter();      
-        this.view.addFilter(filter);
 
-        draggingTileData.view?.rotateToDragTarget(this.view.model);     
+        // Задерживаем вход, чтобы избежать мерцания при быстром движении
+        this.pointerEnterTimer = setTimeout(() => {
+                this.pointerEnterTimer = undefined;
+
+                if (draggingTileData.view) {
+                    if (draggingTileData.view.dragTarget) {
+                        draggingTileData.view.dragTarget.removeTargetGlowFilter();
+                        draggingTileData.view.dragTarget.isDragTarget = false;
+                    }
+                    
+                    draggingTileData.view.dragTarget = this;
+                }
+                
+                this.isDragTarget = true;
+                this.pointerIsOver = true;
+                
+                const filter = this.getTargetGlowFilter();      
+                this.view.addFilter(filter);
+
+                draggingTileData.view?.rotateToDragTarget(this.view.model);
+            },
+            StaticTileView.pointerEnterDelay
+        );
     }
 
-    public onPointerLeave(): void {
-        if (!this.isDragTarget || draggingTileData.view?.dragTarget !== this) {
-            return;
+    public onPointerLeave(event: FederatedPointerEvent): void {
+        if (this.pointerEnterTimer !== undefined) {
+            clearTimeout(this.pointerEnterTimer);
+            this.pointerEnterTimer = undefined;
         }
 
-        this.isDragTarget = false;
-        this.removeTargetGlowFilter();
-        if (draggingTileData.view) {
-            draggingTileData.view.dragTarget = draggingTileData.view.dragSource;
-        }
+        this.pointerIsOver = false;
+
+        // Задерживаем выход, чтобы избежать мерцания
+        this.pointerLeaveTimer = setTimeout(() => {
+                this.pointerLeaveTimer = undefined;
+
+                if (this.pointerIsOver
+                    || !this.isDragTarget
+                    || draggingTileData.view?.dragTarget !== this
+                ) {
+                    return;
+                }
+
+                if (this.getPointerIsInsideWorldHitArea(event)) {
+                    this.pointerIsOver = true;
+                    return;
+                }
+
+                this.isDragTarget = false;
+                this.removeTargetGlowFilter();
+                if (draggingTileData.view) {
+                    draggingTileData.view.dragTarget = draggingTileData.view.dragSource;
+                }
+            },
+            StaticTileView.pointerLeaveDelay
+        );
     }
 
     public onPointerUp(event: FederatedPointerEvent): void {
@@ -144,6 +220,18 @@ export class StaticTileView implements TileView {
                 draggingTileData.view.onGlobalPointerUp(event.nativeEvent);
             }
         }
+    }
+
+    private getPointerIsInsideWorldHitArea(event: FederatedPointerEvent): boolean {
+        if (!this.worldHitArea) {
+            return false;
+        }
+
+        const parent = this.view.tile.parent ?? this.view.tile;
+        const globalPosition = new Point(event.global.x, event.global.y);
+        const parentPosition = parent.toLocal(globalPosition);
+
+        return Algorithm.getPointIsInsidePolygon(parentPosition, this.worldHitArea);
     }
 
     private getTargetGlowFilter(): GlowFilter {
@@ -177,6 +265,16 @@ export class StaticTileView implements TileView {
     }
 
     public destroy(): void {
+        if (this.pointerLeaveTimer !== undefined) {
+            clearTimeout(this.pointerLeaveTimer);
+            this.pointerLeaveTimer = undefined;
+        }
+
+        if (this.pointerEnterTimer !== undefined) {
+            clearTimeout(this.pointerEnterTimer);
+            this.pointerEnterTimer = undefined;
+        }
+
         this.removeEventListeners();
         
         this.view.clearFilters();

--- a/src/views/tiles/TileBaseView.ts
+++ b/src/views/tiles/TileBaseView.ts
@@ -65,6 +65,7 @@ export abstract class TileBaseView implements TileView {
             }
 
             this.updateFiltersTimer = setTimeout(() => {
+                this.updateFiltersTimer = undefined;
                 this.tile.filters = filters;
                 this.tile.updateCacheTexture();
             }, 15);

--- a/src/views/tilings/TilingView.ts
+++ b/src/views/tilings/TilingView.ts
@@ -189,6 +189,7 @@ export class TilingView {
         }
 
         this.imageInitialShowTimer = setTimeout(() => {
+                this.imageInitialShowTimer = undefined;
                 if (this.getStaticTilesAlpha()
                     === this.parameters.staticTileParameters.transparentAlpha) {
                     this.staticTilesAlphaController?.restart(
@@ -196,7 +197,6 @@ export class TilingView {
                         this.parameters.staticTileParameters.defaultAlpha
                     );
                 }
-                this.imageInitialShowTimer = undefined;
             },
             this.parameters.imageInitialShowTime
         );
@@ -266,6 +266,7 @@ export class TilingView {
         // Делаем небольшую паузу на тап, чтобы не было моргания при тапе на фигуре,
         // потому что тап предполагает только поворот, а не длительное перетаскивание        
         this.draggingTileTapTimer = setTimeout(() => {
+                this.draggingTileTapTimer = undefined;
                 if (draggingTileData.view) {
                     const geometryType = event.detail.model.geometry.geometryType;
                     this.setStaticTileFillColor(geometryType, this.targetStaticTileFillColor);
@@ -273,7 +274,6 @@ export class TilingView {
                     window.addEventListener(DraggableTileView.draggingTileWasDeselectedEventName,
                         this.boundOnDraggingTileIsDeselected as EventListener);
                 }
-                this.draggingTileTapTimer = undefined;
             }, 
             this.parameters.tapParameters.maxDuration
         );
@@ -334,6 +334,7 @@ export class TilingView {
             }
 
             this.showPotentialTargetHintGlowFilterTimer = setTimeout(() => {
+                    this.showPotentialTargetHintGlowFilterTimer = undefined;
                     if (this.potentialTargetStaticTileView) {
                         this.potentialTargetStaticTileView.addHintGlowFilter();
                     }


### PR DESCRIPTION
Теперь, когда потенциальная целевая статическая ячейка определена, она подсвечивается, и подсветка не слетает.

Проблема была решена следующим образом.

Когда срабатывает событие покидания ячейки, то берутся координаты указателя, определяется область статического пазла, и происходит сопоставление: указатель всё ещё находится внутри области ячейки или нет?
Если указатель всё ещё внутри ячейки, то действия вследствие мнимого покидания ячейки не выполняются, и ячейка снова становится не покинутой, то есть потенциальной целевой.

Также были произведены небольшие улучшения кода, например, чтобы возможное предотвратить мерцание при перемещении перемещаемого пазла.